### PR TITLE
Change `Alice` to `server`

### DIFF
--- a/md/partially-blind-swap.md
+++ b/md/partially-blind-swap.md
@@ -2,41 +2,37 @@ Partially Blind Atomic Swap Using Adaptor Signatures
 ===========================
 
 In this scheme one of the participants of the swap does not learn which coins
-are being swapped. For example if Alice engages in a partially blind atomic
-swap with Bob and Carol, she would not be able to determine if a swapped output
-belongs to Bob or Carol (assuming the transaction amounts are identical or
-confidential). This property is very similar to
-[TumbleBit](https://eprint.iacr.org/2016/575.pdf) but in the form of a
-[scriptless
-script](https://github.com/apoelstra/scriptless-scripts/blob/master/md/atomic-swap.md)
+are being swapped. For example if Alice as a tumbler service provider engages in
+a partially blind atomic swap with the users Bob and Carol, the tumbler would not
+be able to determine if a swapped output belongs to Bob or Carol (assuming the
+transaction amounts are identical or confidential). This property is very 
+similar to [TumbleBit](https://eprint.iacr.org/2016/575.pdf) but in the form of
+a [scriptlessscript](https://github.com/apoelstra/scriptless-scripts/blob/master/md/atomic-swap.md)
 and therefore purely in the elliptic curve discrete logarithm setting.
 
 The basic idea is that the discrete logarithm of the auxiliary point `T` in the
-adaptor signature is not chosen uniformly at random by Alice. Instead, Bob
-computes `T = t*G` where `t` is a [blind Schnorr
-signature](https://blog.cryptographyengineering.com/a-note-on-blind-signature-schemes/)
-of Alice over a transaction spending the funding transaction without knowing `t`
-(similar to [Discreet Log Contracts](https://adiabat.github.io/dlc.pdf)).
+adaptor signature is not chosen uniformly at random by the server. Instead, the user
+computes `T = t*G` where `t` is a [blind Schnorr signature](https://blog.cryptographyengineering.com/a-note-on-blind-signature-schemes/)
+of the tumbler over a transaction spending the funding transaction without knowing
+`t` (similar to [Discreet Log Contracts](https://adiabat.github.io/dlc.pdf)).
 
 Protocol description
 ---
-Assume Alice has a permanent public key `A = a*G`, ephemeral pubkey `A1 = A +
+Assume the tumbler has a permanent public key `A = a*G`, ephemeral pubkey `A1 = A +
 h*G` where `h` is a tweak that is known to Bob, and ephemeral pubkey `A2` which
-has a secret key known only to Alice and doesn't have to be derived from `A`.
-Bob has two pubkeys `B1 = b1*G` and `B2 = b2*G`
-and `H` is a cryptographic hash function. Public key aggregation in "2-of-2"
-scripts is achieved with [MuSig](https://eprint.iacr.org/2018/068.pdf) and the
-signature scheme is adapted from
-[Bellare-Neven](https://cseweb.ucsd.edu/~mihir/papers/multisignatures-ccs.pdf).
-The partially blind atomic swap protocol where Alice acts as a tumbler works as
-follows.
+has a secret key known only to the tumbler and doesn't have to be derived from `A`.
+Bob has two pubkeys `B1 = b1*G` and `B2 = b2*G` and `H` is a cryptographic hash 
+function. Public key aggregation in "2-of-2" scripts is achieved with [MuSig](https://eprint.iacr.org/2018/068.pdf)
+and the signature scheme is adapted from [Bellare-Neven](https://cseweb.ucsd.edu/~mihir/papers/multisignatures-ccs.pdf).
+The partially blind atomic swap protocol with Alice as tumbler and Bob as a user
+works as follows.
 
 1. Setup
 
-   * Bob anonymously asks Alice to put coins into a key aggregated output O1
-     with public key `P1 = H(A1,B1,A1)*A1 + H(A1,B1,B1)*B1`.
+   * Bob anonymously asks the tumbler to put coins into a key aggregated output 
+     O1 with public key `P1 = H(A1,B1,A1)*A1 + H(A1,B1,B1)*B1`.
    * Bob puts coins into a key aggregated output O2 with `P2 = H(A2,B2,A2)*A2 +
-     H(A2,B2,B2)*B2`. As usual, before sending coins Alice and Bob agree on
+     H(A2,B2,B2)*B2`. As usual, before sending coins tumbler and Bob agree on
      timelocked refund transactions in case one party disappears.
 2. Blind signing
 
@@ -44,7 +40,7 @@ follows.
    point `T = t*G` where `t` is a Schnorr signature over `tx_B` in the
    following way:
 
-    * Bob asks Alice for nonce `Ra = ka*G`
+    * Bob asks the tumbler for nonce `Ra = ka*G`
     * Bob creates nonce `Rb = kb*G`
     * Bob computes
         * the combined nonce `R = Ra+Rb`
@@ -55,21 +51,21 @@ follows.
         * the challenge `c'` for `A1` as part of `P1`: `c' = c1*H(A1,B1,A1)`
         * the blinded challenge `c = c'+beta`
         * and the blinded signature of A times `G`: `T = R + c*A`
-   * Bob sends `c` to Alice
-   * Alice replies with an adaptor signature over `tx_A` spending `O2` with
-     auxiliary point `T = t*G, t = ka + c*a` where `a` is the discrete
+   * Bob sends `c` to the tumbler
+   * The tumbler replies with an adaptor signature over `tx_A` spending `O2`
+     with auxiliary point `T = t*G, t = ka + c*a` where `a` is the discrete
      logarithm of permanent key `A`.
 3. Swap
 
-    * Bob gives Alice his contribution to the signature over `tx_A`.
-    * Alice adds Bob's contribution to her own signature and uses it to take
+    * Bob gives the tumbler his contribution to the signature over `tx_A`.
+    * The tumbler adds Bob's contribution to her own signature and uses it to take
       her coins out of O2.
     * Due to previously receiving an adaptor signature Bob learns `t` from step (2).
 4. Unblinding
 
-   * Bob unblinds Alice's blind signature `t` as `t' = t + alpha + c'*h` where
-     c' is the unblinded challenge `h` is the tweak for `A1`. This results in a
-     regular signature `(R', t')` of Alice (`A1`) over `tx_B`.
+   * Bob unblinds the tumbler's blind signature `t` as `t' = t + alpha + c'*h` where
+     `c'` is the unblinded challenge `h` is the tweak for `A1`. This results in a
+     regular signature `(R', t')` of the tumbler (`A1`) over `tx_B`.
    * Bob adds his contribution to `t'` completing `(R', s), s = t' + kb +
      c1*H(A1,B1,B1)*b1` which is a valid signature over `tx_B` spending O1:
      ```
@@ -84,7 +80,7 @@ follows.
      +------------+  (R', s)   +------------+
      |         O1 +----------->|         ...|
      +------------+            +------------+
-     Alice's setup tx          tx_B
+     the tumbler's setup tx       tx_B
 
      +------------+            +------------+
      |         O2 +----------->|         ...|
@@ -92,9 +88,9 @@ follows.
      Bob's setup tx            tx_A
      ```
 
-As a result, Alice can not link Bob's original coins and his new coins. From
-Alice's perspective `tx_B` could have been just as well the result of a swap
-with someone else.
+As a result, the tumbler can not link Bob's original coins and his new coins.
+From the tumbler's perspective `tx_B` could have been just as well the result
+of a swap with someone else.
 
 Blind Schnorr signatures suffer from a vulnerability known as "parallel attack"
 ([Security of Blind Discrete Log Signatures Against Interactive Attacks, C. P.
@@ -109,20 +105,20 @@ challenge.
 A simpler scheme that would be broken by Aggregated Signatures
 ---
 Note that Bob can get a signature of A over anything including arbitrary
-messages. Therefore, Alice must only use fresh ephemeral keys `A1` when
-creating outputs. This complicates the protocol because at the same time Alice
-must not be able to determine for which exact input she signs. As a result,
-It's Bob's job to apply tweak `h` to convert a signature of `A` to `A1`.
+messages. Therefore, the tumbler must only use fresh ephemeral keys `A1` when
+creating outputs. This complicates the protocol because at the same time the 
+tumbler must not be able to determine for which exact input she signs. As a
+result, It's Bob's job to apply tweak `h` to convert a signature of `A` to `A1`.
 
-A simpler protocol where Alice uses `A` instead of `A1` is broken by aggregated
-signatures because it allows spending multiple inputs with a single signature.
-If Bob creates many funding txs with Alice, he can create a tx spending all of
-them, and prepares a message for Alice to sign which is her part of the
-aggregate signature of all the inputs. Alice just dumbly signs any blinded
-message, so can't decide if it's an aggregated sig or not. For example Bob may
-send Alice a challenge for an aggregate signature covering output 1 with
-pubkeys `L1 = {A, B1}` and output 2 with pubkeys `L2 = {A, B2}` as `c'=H(P1, 0,
-R', tx_B)*H(L1,A) + H(P2, 1, R', tx_B)*H(L2,A)`.
+A simpler protocol where the tumbler uses `A` instead of `A1` is broken by
+aggregated signatures because it allows spending multiple inputs with a single
+signature. If Bob creates many funding txs with the tumbler, he can create a
+tx spending all of them, and prepares a message for the tumbler to sign which is
+her part of the aggregate signature of all the inputs. The tumbler just dumbly 
+signs any blinded message, so can't decide if it's an aggregated sig or not. For
+example Bob may send the tumbler a challenge for an aggregate signature covering
+output 1 with pubkeys `L1 = {A, B1}` and output 2 with pubkeys `L2 = {A, B2}` as
+`c'=H(P1, 0, R', tx_B)*H(L1,A) + H(P2, 1, R', tx_B)*H(L2,A)`.
 
 Similarly, the [SIGHASH_SINGLE
 bug](https://underhandedcrypto.com/2016/08/17/the-2016-backdoored-cryptocurrency-contest-winner/)

--- a/md/partially-blind-swap.md
+++ b/md/partially-blind-swap.md
@@ -2,37 +2,36 @@ Partially Blind Atomic Swap Using Adaptor Signatures
 ===========================
 
 In this scheme one of the participants of the swap does not learn which coins
-are being swapped. For example if Alice as a tumbler service provider engages in
-a partially blind atomic swap with the users Bob and Carol, the tumbler would not
-be able to determine if a swapped output belongs to Bob or Carol (assuming the
-transaction amounts are identical or confidential). This property is very 
-similar to [TumbleBit](https://eprint.iacr.org/2016/575.pdf) but in the form of
-a [scriptlessscript](https://github.com/apoelstra/scriptless-scripts/blob/master/md/atomic-swap.md)
+are being swapped. For example if service provider engages in a partially blind 
+atomic swap with the users Bob and Carol, the server would not be able to 
+determine if a swapped output belongs to Bob or Carol (assuming the transaction 
+amounts are identical or confidential). This property is very similar to 
+[TumbleBit](https://eprint.iacr.org/2016/575.pdf) but in the form of a [scriptlessscript](https://github.com/apoelstra/scriptless-scripts/blob/master/md/atomic-swap.md)
 and therefore purely in the elliptic curve discrete logarithm setting.
 
 The basic idea is that the discrete logarithm of the auxiliary point `T` in the
 adaptor signature is not chosen uniformly at random by the server. Instead, the user
 computes `T = t*G` where `t` is a [blind Schnorr signature](https://blog.cryptographyengineering.com/a-note-on-blind-signature-schemes/)
-of the tumbler over a transaction spending the funding transaction without knowing
+of the server over a transaction spending the funding transaction without knowing
 `t` (similar to [Discreet Log Contracts](https://adiabat.github.io/dlc.pdf)).
 
 Protocol description
 ---
-Assume the tumbler has a permanent public key `A = a*G`, ephemeral pubkey `A1 = A +
+Assume the server has a permanent public key `A = a*G`, ephemeral pubkey `A1 = A +
 h*G` where `h` is a tweak that is known to Bob, and ephemeral pubkey `A2` which
-has a secret key known only to the tumbler and doesn't have to be derived from `A`.
+has a secret key known only to the server and doesn't have to be derived from `A`.
 Bob has two pubkeys `B1 = b1*G` and `B2 = b2*G` and `H` is a cryptographic hash 
 function. Public key aggregation in "2-of-2" scripts is achieved with [MuSig](https://eprint.iacr.org/2018/068.pdf)
 and the signature scheme is adapted from [Bellare-Neven](https://cseweb.ucsd.edu/~mihir/papers/multisignatures-ccs.pdf).
-The partially blind atomic swap protocol with Alice as tumbler and Bob as a user
+The partially blind atomic swap protocol with the server and Bob as a user
 works as follows.
 
 1. Setup
 
-   * Bob anonymously asks the tumbler to put coins into a key aggregated output 
+   * Bob anonymously asks the server to put coins into a key aggregated output 
      O1 with public key `P1 = H(A1,B1,A1)*A1 + H(A1,B1,B1)*B1`.
    * Bob puts coins into a key aggregated output O2 with `P2 = H(A2,B2,A2)*A2 +
-     H(A2,B2,B2)*B2`. As usual, before sending coins tumbler and Bob agree on
+     H(A2,B2,B2)*B2`. As usual, before sending coins server and Bob agree on
      timelocked refund transactions in case one party disappears.
 2. Blind signing
 
@@ -40,7 +39,7 @@ works as follows.
    point `T = t*G` where `t` is a Schnorr signature over `tx_B` in the
    following way:
 
-    * Bob asks the tumbler for nonce `Ra = ka*G`
+    * Bob asks the server for nonce `Ra = ka*G`
     * Bob creates nonce `Rb = kb*G`
     * Bob computes
         * the combined nonce `R = Ra+Rb`
@@ -51,21 +50,21 @@ works as follows.
         * the challenge `c'` for `A1` as part of `P1`: `c' = c1*H(A1,B1,A1)`
         * the blinded challenge `c = c'+beta`
         * and the blinded signature of A times `G`: `T = R + c*A`
-   * Bob sends `c` to the tumbler
-   * The tumbler replies with an adaptor signature over `tx_A` spending `O2`
+   * Bob sends `c` to the server
+   * The server replies with an adaptor signature over `tx_A` spending `O2`
      with auxiliary point `T = t*G, t = ka + c*a` where `a` is the discrete
      logarithm of permanent key `A`.
 3. Swap
 
-    * Bob gives the tumbler his contribution to the signature over `tx_A`.
-    * The tumbler adds Bob's contribution to her own signature and uses it to take
+    * Bob gives the server his contribution to the signature over `tx_A`.
+    * The server adds Bob's contribution to her own signature and uses it to take
       her coins out of O2.
     * Due to previously receiving an adaptor signature Bob learns `t` from step (2).
 4. Unblinding
 
-   * Bob unblinds the tumbler's blind signature `t` as `t' = t + alpha + c'*h` where
+   * Bob unblinds the server's blind signature `t` as `t' = t + alpha + c'*h` where
      `c'` is the unblinded challenge `h` is the tweak for `A1`. This results in a
-     regular signature `(R', t')` of the tumbler (`A1`) over `tx_B`.
+     regular signature `(R', t')` of the server (`A1`) over `tx_B`.
    * Bob adds his contribution to `t'` completing `(R', s), s = t' + kb +
      c1*H(A1,B1,B1)*b1` which is a valid signature over `tx_B` spending O1:
      ```
@@ -80,7 +79,7 @@ works as follows.
      +------------+  (R', s)   +------------+
      |         O1 +----------->|         ...|
      +------------+            +------------+
-     the tumbler's setup tx       tx_B
+     the server's setup tx     tx_B
 
      +------------+            +------------+
      |         O2 +----------->|         ...|
@@ -88,8 +87,8 @@ works as follows.
      Bob's setup tx            tx_A
      ```
 
-As a result, the tumbler can not link Bob's original coins and his new coins.
-From the tumbler's perspective `tx_B` could have been just as well the result
+As a result, the server can not link Bob's original coins and his new coins.
+From the server's perspective `tx_B` could have been just as well the result
 of a swap with someone else.
 
 Blind Schnorr signatures suffer from a vulnerability known as "parallel attack"
@@ -105,18 +104,18 @@ challenge.
 A simpler scheme that would be broken by Aggregated Signatures
 ---
 Note that Bob can get a signature of A over anything including arbitrary
-messages. Therefore, the tumbler must only use fresh ephemeral keys `A1` when
+messages. Therefore, the server must only use fresh ephemeral keys `A1` when
 creating outputs. This complicates the protocol because at the same time the 
-tumbler must not be able to determine for which exact input she signs. As a
+server must not be able to determine for which exact input she signs. As a
 result, It's Bob's job to apply tweak `h` to convert a signature of `A` to `A1`.
 
-A simpler protocol where the tumbler uses `A` instead of `A1` is broken by
+A simpler protocol where the server uses `A` instead of `A1` is broken by
 aggregated signatures because it allows spending multiple inputs with a single
-signature. If Bob creates many funding txs with the tumbler, he can create a
-tx spending all of them, and prepares a message for the tumbler to sign which is
-her part of the aggregate signature of all the inputs. The tumbler just dumbly 
+signature. If Bob creates many funding txs with the server, he can create a
+tx spending all of them, and prepares a message for the server to sign which is
+her part of the aggregate signature of all the inputs. The server just dumbly 
 signs any blinded message, so can't decide if it's an aggregated sig or not. For
-example Bob may send the tumbler a challenge for an aggregate signature covering
+example Bob may send the server a challenge for an aggregate signature covering
 output 1 with pubkeys `L1 = {A, B1}` and output 2 with pubkeys `L2 = {A, B2}` as
 `c'=H(P1, 0, R', tx_B)*H(L1,A) + H(P2, 1, R', tx_B)*H(L2,A)`.
 


### PR DESCRIPTION
In the current version, I always get confused who is the tumbler, either Alice or Bob. The two are not peers [Bob knows more than Alice] and the two have different tasks, so I think it is better to differentiate them more clearly. In this PR I call `Alice` the `tumbler service provider` and `Bob` and `Carol` are the `users` and I replace most of her name with `the tumbler` so that it is always clear who has which role. In my opinion, this makes it a lot easier to conceptualize.